### PR TITLE
Done adding support for one time task under a view

### DIFF
--- a/Sources/Components/Modifiers/TaskModifier.swift
+++ b/Sources/Components/Modifiers/TaskModifier.swift
@@ -1,0 +1,44 @@
+//
+//  SwiftUIView.swift
+//
+//
+//  Created by Daniel Mandea on 24.03.2024.
+//
+
+import SwiftUI
+
+public struct TaskModifier: ViewModifier {
+    
+    // MARK: - Private
+    
+    private let oneTask: @Sendable () async -> Void
+    private let priority: TaskPriority
+    
+    // MARK: - State
+    
+    @State private var hasAppeared = false
+    
+    // MARK: - Init
+    
+    public init(priority: TaskPriority = .userInitiated, _ oneTask: @escaping @Sendable () async -> Void) {
+        self.priority = priority
+        self.oneTask = oneTask
+    }
+    
+    // MARK: - Body
+    
+    public func body(content: Content) -> some View {
+        content
+            .task(priority: priority) {
+                guard !hasAppeared else { return }
+                hasAppeared = true
+                await oneTask()
+            }
+    }
+}
+
+extension View {
+    public func oneTask(priority: TaskPriority = .userInitiated, _ action: @escaping @Sendable () async -> Void) -> some View{
+        modifier(TaskModifier(priority: priority, action))
+    }
+}

--- a/Tests/ComponentsTests/LocalizationTests.swift
+++ b/Tests/ComponentsTests/LocalizationTests.swift
@@ -10,6 +10,6 @@ final class LocalizationTests: XCTestCase {
     }
     
     func testGenericErrorMessageLocalization() {
-        XCTAssertEqual(L10n.genericErrorMessage, "Oops Something went wrong.")
+        XCTAssertEqual(L10n.genericErrorMessage, "Oops something went wrong.")
     }
 }

--- a/Tests/ComponentsTests/TaskModiferTests.swift
+++ b/Tests/ComponentsTests/TaskModiferTests.swift
@@ -1,0 +1,23 @@
+//
+//  TaskModiferTests.swift
+//
+//
+//  Created by Daniel Mandea on 24.03.2024.
+//
+
+import XCTest
+import SwiftUI
+@testable import Components
+
+final class TaskModiferTests: XCTestCase {
+    
+    func testInit() throws {
+        XCTAssertNotNil(TaskModifier{})
+    }
+    
+    func testExtension() {
+        XCTAssertNotNil(Text("Hello")
+            .oneTask { } as? ModifiedContent<Text, TaskModifier>
+        )
+    }
+}


### PR DESCRIPTION
Done adding support for `oneTask { }` under `View` it supports async `Task` similar to `task{}`